### PR TITLE
compat with new futures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ edition = "2018"
 [dependencies]
 
 [dev-dependencies]
-futures-preview = "0.3.0-alpha.13"
+futures-preview = "0.3.0-alpha.14"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ __Basic usage__
 #![feature(futures_api)]
 
 use std::pin::Pin;
-use std::task::{Poll, Waker};
+use std::task::{Context, Poll};
 use futures::prelude::*;
 use async_ready::AsyncReady;
 use std::io;
@@ -24,7 +24,7 @@ struct Fut;
 
 impl Future for Fut {
   type Output = ();
-  fn poll(self: Pin<&mut Self>, waker: &Waker) -> Poll<Self::Output> {
+  fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
     Poll::Ready(())
   }
 }
@@ -33,8 +33,10 @@ impl AsyncReady for Fut {
   type Ok = ();
   type Err = io::Error;
 
-  fn poll_ready(&mut self, waker: &Waker)
-    -> Poll<Result<Self::Ok, Self::Err>> {
+  fn poll_ready(
+    mut self: Pin<&mut Self>,
+    cx: &mut Context<'_>,
+  ) -> Poll<Result<Self::Ok, Self::Err>> {
     Poll::Ready(Ok(()))
   }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!
 //! impl Future for Fut {
 //!   type Output = ();
-//!   fn poll(self: Pin<&mut Self>, waker: &Waker) -> Poll<Self::Output> {
+//!   fn poll(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Self::Output> {
 //!     Poll::Ready(())
 //!   }
 //! }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,10 @@
 //!   type Ok = ();
 //!   type Err = io::Error;
 //!
-//!   fn poll_ready(&mut self, waker: &Waker)
-//!     -> Poll<Result<Self::Ok, Self::Err>> {
+//!   fn poll_ready(
+//!     mut self: Pin<&mut Self>,
+//!     cx: &mut Context<'_>,
+//!   ) -> Poll<Result<Self::Ok, Self::Err>> {
 //!     Poll::Ready(Ok(()))
 //!   }
 //! }
@@ -39,7 +41,7 @@
 
 #![feature(futures_api)]
 
-use std::task::{Poll, Waker};
+use std::task::{Context, Poll};
 
 /// Determine if the underlying API can be written to.
 pub trait AsyncWriteReady {
@@ -50,7 +52,10 @@ pub trait AsyncWriteReady {
   type Err: std::error::Error + Send + Sync;
 
   /// Check if the underlying API can be written to.
-  fn poll_write_ready(&self, waker: &Waker) -> Poll<Result<Self::Ok, Self::Err>>;
+  fn poll_write_ready(
+    mut self: Pin<&mut Self>,
+    cx: &mut Context<'_>,
+  ) -> Poll<Result<Self::Ok, Self::Err>>;
 }
 
 /// Determine if the underlying API can be read from.
@@ -62,7 +67,10 @@ pub trait AsyncReadReady {
   type Err: std::error::Error + Send + Sync;
 
   /// Check if the underlying API can be read from.
-  fn poll_read_ready(&self, waker: &Waker) -> Poll<Result<Self::Ok, Self::Err>>;
+  fn poll_read_ready(
+    mut self: Pin<&mut Self>,
+    cx: &mut Context<'_>,
+  ) -> Poll<Result<Self::Ok, Self::Err>>;
 }
 
 /// Determine if a struct is async-ready to yield futures.
@@ -81,7 +89,10 @@ pub trait AsyncReady {
   type Err: std::error::Error + Send + Sync;
 
   /// Check if the stream can be read from.
-  fn poll_ready(&self, waker: &Waker) -> Poll<Result<Self::Ok, Self::Err>>;
+  fn poll_ready(
+    mut self: Pin<&mut Self>,
+    cx: &mut Context<'_>,
+  ) -> Poll<Result<Self::Ok, Self::Err>>;
 }
 
 /// Extract an error from the underlying struct that isn't propagated through

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! #![feature(futures_api)]
 //!
 //! use std::pin::Pin;
-//! use std::task::{Poll, Waker};
+//! use std::task::{Context, Poll};
 //! use futures::prelude::*;
 //! use async_ready::AsyncReady;
 //! use std::io;
@@ -41,6 +41,7 @@
 
 #![feature(futures_api)]
 
+use std::pin::Pin;
 use std::task::{Context, Poll};
 
 /// Determine if the underlying API can be written to.
@@ -53,7 +54,7 @@ pub trait AsyncWriteReady {
 
   /// Check if the underlying API can be written to.
   fn poll_write_ready(
-    mut self: Pin<&mut Self>,
+    self: Pin<&mut Self>,
     cx: &mut Context<'_>,
   ) -> Poll<Result<Self::Ok, Self::Err>>;
 }
@@ -68,7 +69,7 @@ pub trait AsyncReadReady {
 
   /// Check if the underlying API can be read from.
   fn poll_read_ready(
-    mut self: Pin<&mut Self>,
+    self: Pin<&mut Self>,
     cx: &mut Context<'_>,
   ) -> Poll<Result<Self::Ok, Self::Err>>;
 }
@@ -90,7 +91,7 @@ pub trait AsyncReady {
 
   /// Check if the stream can be read from.
   fn poll_ready(
-    mut self: Pin<&mut Self>,
+    self: Pin<&mut Self>,
     cx: &mut Context<'_>,
   ) -> Poll<Result<Self::Ok, Self::Err>>;
 }


### PR DESCRIPTION
Compat with the new futures API from https://github.com/rust-lang-nursery/futures-rs/pull/1514. We should wait on that to merge before we publish. Thanks!