### PR TITLE
poll_unpin types

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,17 @@ pub trait AsyncWriteReady {
     self: Pin<&mut Self>,
     cx: &mut Context<'_>,
   ) -> Poll<Result<Self::Ok, Self::Err>>;
+
+  /// A convenience for calling `AsyncWriteReady::poll_write_ready` on `Unpin` types.
+  fn poll_write_ready_unpin(
+    self: Pin<&mut Self>,
+    cx: &mut Context<'_>,
+  ) -> Poll<Result<Self::Ok, Self::Err>>
+  where
+    Self: Unpin + Sized,
+  {
+    Pin::new(self).poll_write_ready(cx)
+  }
 }
 
 /// Determine if the underlying API can be read from.
@@ -72,6 +83,17 @@ pub trait AsyncReadReady {
     self: Pin<&mut Self>,
     cx: &mut Context<'_>,
   ) -> Poll<Result<Self::Ok, Self::Err>>;
+
+  /// A convenience for calling `AsyncReadReady::poll_read_ready` on `Unpin` types.
+  fn poll_read_ready_unpin(
+    self: Pin<&mut Self>,
+    cx: &mut Context<'_>,
+  ) -> Poll<Result<Self::Ok, Self::Err>>
+  where
+    Self: Unpin + Sized,
+  {
+    Pin::new(self).poll_read_ready(cx)
+  }
 }
 
 /// Determine if a struct is async-ready to yield futures.
@@ -94,6 +116,17 @@ pub trait AsyncReady {
     self: Pin<&mut Self>,
     cx: &mut Context<'_>,
   ) -> Poll<Result<Self::Ok, Self::Err>>;
+
+  /// A convenience for calling `AsyncReady::poll_ready` on `Unpin` types.
+  fn poll_ready_unpin(
+    self: Pin<&mut Self>,
+    cx: &mut Context<'_>,
+  ) -> Poll<Result<Self::Ok, Self::Err>>
+  where
+    Self: Unpin + Sized,
+  {
+    Pin::new(self).poll_ready(cx)
+  }
 }
 
 /// Extract an error from the underlying struct that isn't propagated through

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ pub trait AsyncWriteReady {
   where
     Self: Unpin + Sized,
   {
-    Pin::new(self).poll_write_ready(cx)
+    self.poll_write_ready(cx)
   }
 }
 
@@ -92,7 +92,7 @@ pub trait AsyncReadReady {
   where
     Self: Unpin + Sized,
   {
-    Pin::new(self).poll_read_ready(cx)
+    self.poll_read_ready(cx)
   }
 }
 
@@ -125,7 +125,7 @@ pub trait AsyncReady {
   where
     Self: Unpin + Sized,
   {
-    Pin::new(self).poll_ready(cx)
+    self.poll_ready(cx)
   }
 }
 


### PR DESCRIPTION
Adds unpin methods to the traits, similar to [Future's unpin traits](https://rust-lang-nursery.github.io/futures-api-docs/0.3.0-alpha.14/futures/future/trait.FutureExt.html#method.poll_unpin).

Not quite sure why this isn't working out tho. Need to investigate.