### PR TITLE
 poll_*_unpin takes &mut self 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 //! ## Example
 //!
 //! ```rust
-//! #![feature(futures_api)]
 //!
 //! use std::pin::Pin;
 //! use std::task::{Context, Poll};
@@ -38,8 +37,6 @@
 //!   }
 //! }
 //! ```
-
-#![feature(futures_api)]
 
 use std::pin::Pin;
 use std::task::{Context, Poll};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,13 +57,13 @@ pub trait AsyncWriteReady {
 
   /// A convenience for calling `AsyncWriteReady::poll_write_ready` on `Unpin` types.
   fn poll_write_ready_unpin(
-    self: Pin<&mut Self>,
+    &mut self,
     cx: &mut Context<'_>,
   ) -> Poll<Result<Self::Ok, Self::Err>>
   where
     Self: Unpin + Sized,
   {
-    self.poll_write_ready(cx)
+    Pin::new(self).poll_write_ready(cx)
   }
 }
 
@@ -83,13 +83,13 @@ pub trait AsyncReadReady {
 
   /// A convenience for calling `AsyncReadReady::poll_read_ready` on `Unpin` types.
   fn poll_read_ready_unpin(
-    self: Pin<&mut Self>,
+    &mut self,
     cx: &mut Context<'_>,
   ) -> Poll<Result<Self::Ok, Self::Err>>
   where
     Self: Unpin + Sized,
   {
-    self.poll_read_ready(cx)
+    Pin::new(self).poll_read_ready(cx)
   }
 }
 
@@ -116,13 +116,13 @@ pub trait AsyncReady {
 
   /// A convenience for calling `AsyncReady::poll_ready` on `Unpin` types.
   fn poll_ready_unpin(
-    self: Pin<&mut Self>,
+    &mut self,
     cx: &mut Context<'_>,
   ) -> Poll<Result<Self::Ok, Self::Err>>
   where
     Self: Unpin + Sized,
   {
-    self.poll_ready(cx)
+    Pin::new(self).poll_ready(cx)
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->
🐛 bug fix

<!-- Provide a general summary of the changes in the title above -->

## Context
Discussed in #5, related to #2.
I also took the liberty to remove #![feature(futures_api)], because that was stabilized and it doesn't compile due to deny(warnings)

## Semver Changes
<!-- Which semantic version change would you recommend? -->
Technically, this is a breaking change, so 3.0?